### PR TITLE
Updated freezed_annotations version

### DIFF
--- a/lib/src/rsa_drivers_license.dart
+++ b/lib/src/rsa_drivers_license.dart
@@ -57,7 +57,7 @@ class RsaDriversLicense implements RsaIdDocument {
   final String driverRestrictions;
 
   /// The expiry date of the PrDP Permit.
-  final DateTime prdpExpiry;
+  final DateTime? prdpExpiry;
 
   /// The issue number of this license.
   final String licenseIssueNumber;
@@ -75,7 +75,7 @@ class RsaDriversLicense implements RsaIdDocument {
   /// The image data of the photo on this license in bytes.
   ///
   /// TODO: Determine how this data can be decoded to provide an actual image.
-  final Uint8List imageData;
+  final Uint8List? imageData;
 
   const RsaDriversLicense({
     required this.idNumber,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   asn1lib: ^1.0.2
-  freezed_annotation: ^0.14.2
+  freezed_annotation: ^1.1.0
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rsa_identification
 description: A Dart Library for decoding and providing South African identification details from documents such as Driver's licenses and Smart ID's.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/born-ideas/rsa_identification
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,8 @@ environment:
 
 dependencies:
   asn1lib: ^1.0.2
-  freezed_annotation: ^1.1.0
 
 dev_dependencies:
   pedantic: ^1.11.0
   test: ^1.17.7
-  freezed: ^0.14.2
   build_runner: ^2.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: rsa_identification
 description: A Dart Library for decoding and providing South African identification details from documents such as Driver's licenses and Smart ID's.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/born-ideas/rsa_identification
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
   asn1lib: ^1.0.2


### PR DESCRIPTION
We use rsa_identification in serveral production apps, and the freezed_annotations package's version is witholding use of other packages like isar.